### PR TITLE
Added autoload support

### DIFF
--- a/driver.js
+++ b/driver.js
@@ -51,7 +51,7 @@ class Driver {
         if (isInBrowser) {
             this._triggerCell.addEventListener('click', this._triggerLink);
             this._triggerCell.classList.add('ready');
-            (featureURLSupported && new URL(window.location.href).searchParams.get(autoStartParam)) ?  this._triggerLink()
+            (featureURLSupported && new URL(window.location.href).searchParams.get(autoStartParam)) ? this._triggerLink() : null;
         }
     }
     

--- a/driver.js
+++ b/driver.js
@@ -23,6 +23,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 "use strict";
+const featureURLSupported = typeof URL === 'function';
+const autoStartParam = 'autoload';
 
 class Driver {
     constructor(statusCell, triggerCell, triggerLink, magicCell, summaryCell, key)
@@ -49,6 +51,7 @@ class Driver {
         if (isInBrowser) {
             this._triggerCell.addEventListener('click', this._triggerLink);
             this._triggerCell.classList.add('ready');
+            (featureURLSupported && new URL(window.location.href).searchParams.get(autoStartParam)) ?  this._triggerLink()
         }
     }
     


### PR DESCRIPTION
I would like to be able to direct a browser at ARES programmatically and start the benchmark without manual intervention. This PR allows that with minimal code refactor.

Added autoload support
Added browser check for URL feature
Assuming same support as `const` that `let` has (was already in use)